### PR TITLE
Update carbon_return.py

### DIFF
--- a/salt/returners/carbon_return.py
+++ b/salt/returners/carbon_return.py
@@ -170,7 +170,7 @@ def _send_textmetrics(metrics):
 
     data = [" ".join(map(str, metric)) for metric in metrics] + [""]
 
-    return "\n".join(data)
+    return "\n".join(data).encode()
 
 
 def _walk(path, value, metrics, timestamp, skip):


### PR DESCRIPTION
Fix munin.run carbon return error:

2020-09-09 17:01:01,112 [salt.utils.schedule:853 ][ERROR   ][2099938] Unhandled exception running munin.run
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/salt/utils/schedule.py", line 844, in handle_func
    self.returners[ret_str](ret)
  File "/usr/lib/python3/dist-packages/salt/returners/carbon_return.py", line 299, in returner
    _send(saltdata, metric_base, opts)
  File "/usr/lib/python3/dist-packages/salt/returners/carbon_return.py", line 257, in _send
    sent_bytes = sock.send(data[total_sent_bytes:])
TypeError: a bytes-like object is required, not 'str'

### What does this PR do?

### What issues does this PR fix or reference?
Fixes:

### Previous Behavior
Remove this section if not relevant

### New Behavior
Remove this section if not relevant

### Merge requirements satisfied?
**[NOTICE] Bug fixes or features added to Salt require tests.**
<!-- Please review the [test documentation](https://docs.saltstack.com/en/master/topics/tutorials/writing_tests.html) for details on how to implement tests into Salt's test suite. -->
- [ ] Docs
- [ ] Changelog - https://docs.saltstack.com/en/master/topics/development/changelog.html
- [ ] Tests written/updated

### Commits signed with GPG?
Yes/No

Please review [Salt's Contributing Guide](https://docs.saltstack.com/en/master/topics/development/contributing.html) for best practices.

See GitHub's [page on GPG signing](https://help.github.com/articles/signing-commits-using-gpg/) for more information about signing commits with GPG.
